### PR TITLE
Bump commons-net from 3.6 to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>3.6</version>
+            <version>3.9.0</version>
         </dependency>
 
         <!-- HttpClient SSRF -->


### PR DESCRIPTION
Bumps commons-net from 3.6 to 3.9.0.

---
updated-dependencies:
- dependency-name: commons-net:commons-net dependency-type: direct:production ...