### PR TITLE
Bump jolokia-core from 1.6.0 to 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-core</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
 
         <!-- 添加SpringBoot Actuator-->


### PR DESCRIPTION
Bumps jolokia-core from 1.6.0 to 1.6.1.

---
updated-dependencies:
- dependency-name: org.jolokia:jolokia-core dependency-type: direct:production ...