### PR TITLE
Bump poi from 3.10-FINAL to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>3.10-FINAL</version>
+            <version>4.1.1</version>
         </dependency>
 
         <!-- vuln maven jar. Solve xlsx.-->


### PR DESCRIPTION
Bumps poi from 3.10-FINAL to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi dependency-type: direct:production ...